### PR TITLE
Fix/projects centroid

### DIFF
--- a/client/src/containers/datasets/layers/projects/hooks.tsx
+++ b/client/src/containers/datasets/layers/projects/hooks.tsx
@@ -12,6 +12,7 @@ export function useLayers({
       id: 'projects_points_shadow',
       type: 'circle',
       source: 'projects',
+      filter: ['==', ['get', 'type'], 'centroid'],
       'source-layer': 'afoco_locations_full',
       paint: {
         'circle-radius': 5,
@@ -27,6 +28,7 @@ export function useLayers({
     {
       id: 'projects',
       type: 'circle',
+      filter: ['==', ['get', 'type'], 'centroid'],
       source: 'projects',
       'source-layer': 'afoco_locations_full',
       paint: {
@@ -53,13 +55,12 @@ export function useLayers({
       source: 'projects',
       'source-layer': 'afoco_locations_full',
       paint: {
-        // 'line-color': [
-        //   'case',
-        //   ['boolean', ['feature-state', 'hover'], false],
-        //   '#176252',
-        //   '#170099',
-        // ],
-        'line-color': '#176252',
+        'line-color': [
+          'case',
+          ['boolean', ['feature-state', 'hover'], false],
+          '#EFB82A',
+          '#176252',
+        ],
         'line-opacity': opacity,
         'line-width': 1.5,
       },
@@ -75,13 +76,12 @@ export function useLayers({
       source: 'projects',
       'source-layer': 'afoco_locations_full',
       paint: {
-        // 'fill-color': [
-        //   'case',
-        //   ['boolean', ['feature-state', 'hover'], false],
-        //   '#176252',
-        //   '#170099',
-        // ],
-        'fill-color': '#176252',
+        'fill-color': [
+          'case',
+          ['boolean', ['feature-state', 'hover'], false],
+          '#EFB82A',
+          '#176252',
+        ],
         'fill-opacity': opacity * 0.4,
       },
       layout: {

--- a/client/src/containers/datasets/layers/projects/hooks.tsx
+++ b/client/src/containers/datasets/layers/projects/hooks.tsx
@@ -1,18 +1,48 @@
 import type { LayerProps } from 'react-map-gl';
 
-import { LayerSettings } from '@/types/layers';
+import { useAtomValue } from 'jotai';
+
+import { hoveredProjectListAtom } from '@/store';
+
+import type { LayerSettings } from '@/types/layers';
 
 export function useLayers({
   settings: { opacity = 1, visibility = 'visible' },
 }: {
   settings: { opacity: LayerSettings['opacity']; visibility: LayerSettings['visibility'] };
 }): LayerProps[] {
+  const hoveredProject = useAtomValue(hoveredProjectListAtom);
+
+  let filterProjectCentroid;
+  if (hoveredProject === null) {
+    // Apply filter by type == 'centroid' only
+    filterProjectCentroid = ['==', ['get', 'type'], 'centroid'];
+  } else {
+    // Apply filter by both type == 'centroid' and project_code == hoveredProject
+    filterProjectCentroid = [
+      'all',
+      ['==', ['get', 'type'], 'centroid'],
+      ['==', ['get', 'project_code'], hoveredProject],
+    ];
+  }
+
+  // The layer is designed to react both to hover events directly on the map and to hover events over a specific project listed in a sidebar.
+
+  // Reactivity to Hover Events on the Map:
+  // When a user hovers over the map layer, both point and geometry representations within the layer are programmed to change in color and/or size.
+
+  // Reactivity to Hover Events in the Sidebar:
+  // Similarly, When a user hovers over the a project in the sidebar, both point and geometry representations within the layer are programmed to change in color and/or size.
+
+  // Filtering Mechanism:
+  // Alongside the visual changes, hovering over a project in the sidebar also activates a filtering mechanism on the map layer.
+  // This filter hides the rest of the projects on the map.
   return [
     {
       id: 'projects_points_shadow',
       type: 'circle',
       source: 'projects',
-      filter: ['==', ['get', 'type'], 'centroid'],
+      filter: filterProjectCentroid,
       'source-layer': 'afoco_locations_full',
       paint: {
         'circle-radius': 5,
@@ -28,16 +58,32 @@ export function useLayers({
     {
       id: 'projects',
       type: 'circle',
-      filter: ['==', ['get', 'type'], 'centroid'],
+      filter: filterProjectCentroid,
       source: 'projects',
       'source-layer': 'afoco_locations_full',
       paint: {
         'circle-stroke-color': '#ffffff',
-        'circle-stroke-width': ['case', ['boolean', ['feature-state', 'hover'], false], 3, 7],
-        'circle-radius': ['case', ['boolean', ['feature-state', 'hover'], false], 13, 7],
+        'circle-stroke-width': [
+          'case',
+          ['boolean', ['feature-state', 'hover'], false],
+          3,
+          ['==', ['get', 'project_code'], hoveredProject],
+          3,
+          7,
+        ],
+        'circle-radius': [
+          'case',
+          ['boolean', ['feature-state', 'hover'], false],
+          13,
+          ['==', ['get', 'project_code'], hoveredProject],
+          13,
+          7,
+        ],
         'circle-color': [
           'case',
           ['boolean', ['feature-state', 'hover'], false],
+          '#EFB82A',
+          ['==', ['get', 'project_code'], hoveredProject],
           '#EFB82A',
           '#176252',
         ],
@@ -54,10 +100,13 @@ export function useLayers({
       type: 'line',
       source: 'projects',
       'source-layer': 'afoco_locations_full',
+      ...(!!hoveredProject && { filter: ['==', ['get', 'project_code'], hoveredProject] }),
       paint: {
         'line-color': [
           'case',
           ['boolean', ['feature-state', 'hover'], false],
+          '#EFB82A',
+          ['==', ['get', 'project_code'], hoveredProject],
           '#EFB82A',
           '#176252',
         ],
@@ -75,10 +124,13 @@ export function useLayers({
       type: 'fill',
       source: 'projects',
       'source-layer': 'afoco_locations_full',
+      ...(!!hoveredProject && { filter: ['==', ['get', 'project_code'], hoveredProject] }),
       paint: {
         'fill-color': [
           'case',
           ['boolean', ['feature-state', 'hover'], false],
+          '#EFB82A',
+          ['==', ['get', 'project_code'], hoveredProject],
           '#EFB82A',
           '#176252',
         ],

--- a/client/src/containers/datasets/layers/projects/layer.tsx
+++ b/client/src/containers/datasets/layers/projects/layer.tsx
@@ -1,3 +1,5 @@
+import { useEffect } from 'react';
+
 import { Layer, Source, SourceProps } from 'react-map-gl';
 
 import type { LayerProps } from '@/types/layers';
@@ -13,8 +15,9 @@ const SOURCE: SourceProps = {
   id: 'projects',
 };
 
-export const ProjectsLayer = ({ beforeId, id }: LayerProps) => {
+export const ProjectsLayer = ({ beforeId, id, onAdd, onRemove }: LayerProps) => {
   const [layers] = useSyncLayers();
+
   const settings = layers.find((layer) => layer.id === id) || {
     visibility: 'visible',
     opacity: 1,
@@ -22,6 +25,14 @@ export const ProjectsLayer = ({ beforeId, id }: LayerProps) => {
   const LAYERS = useLayers({
     settings,
   });
+
+  useEffect(() => {
+    const ids = LAYERS.map((layer) => layer.id);
+    onAdd && onAdd(ids);
+    return () => onRemove && onRemove(ids);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [layers, onAdd, onRemove]);
+
   if (!SOURCE || !LAYERS.length) return null;
 
   return (

--- a/client/src/containers/map/index.tsx
+++ b/client/src/containers/map/index.tsx
@@ -122,7 +122,6 @@ export default function MapContainer() {
       const ProjectsFillLayer =
         e?.features && e?.features.find(({ layer }) => layer.id === 'projects_fill');
 
-      console.log(ProjectsFillLayer, e?.features);
       // *ON MOUSE ENTER
       if (e.features && map && ProjectsLayer) {
         setCursor('pointer');

--- a/client/src/containers/map/index.tsx
+++ b/client/src/containers/map/index.tsx
@@ -113,14 +113,25 @@ export default function MapContainer() {
   );
 
   let hoveredStateIdProjectsCircle: string | null = null;
+  let hoveredStateIdProjectsFill: string | null = null;
 
   const handleMouseMove = useCallback(
     (e: MapLayerMouseEvent) => {
       const ProjectsLayer = e?.features && e?.features.find(({ layer }) => layer.id === 'projects');
+
+      const ProjectsFillLayer =
+        e?.features && e?.features.find(({ layer }) => layer.id === 'projects_fill');
+
+      console.log(ProjectsFillLayer, e?.features);
       // *ON MOUSE ENTER
       if (e.features && map && ProjectsLayer) {
         setCursor('pointer');
         setHoveredProject(ProjectsLayer.properties?.project_code);
+      }
+
+      if (e.features && map && ProjectsFillLayer) {
+        setCursor('pointer');
+        setHoveredProject(ProjectsFillLayer.properties?.project_code);
       }
 
       if (ProjectsLayer && map) {
@@ -145,6 +156,28 @@ export default function MapContainer() {
           { hover: true }
         );
       }
+      if (ProjectsFillLayer && map) {
+        if (hoveredStateIdProjectsFill !== null) {
+          map?.setFeatureState(
+            {
+              sourceLayer: 'afoco_locations_full',
+              source: 'projects',
+              id: hoveredStateIdProjectsFill,
+            },
+            { hover: false }
+          );
+        }
+
+        hoveredStateIdProjectsFill = ProjectsFillLayer?.properties?.project_code as string;
+        map?.setFeatureState(
+          {
+            sourceLayer: 'afoco_locations_full',
+            source: 'projects',
+            id: hoveredStateIdProjectsFill,
+          },
+          { hover: true }
+        );
+      }
 
       // *ON MOUSE LEAVE
 
@@ -165,8 +198,21 @@ export default function MapContainer() {
         );
         hoveredStateIdProjectsCircle = null;
       }
+      if (!ProjectsFillLayer && map && hoveredStateIdProjectsFill) {
+        setHoveredProject(null);
+
+        map?.setFeatureState(
+          {
+            sourceLayer: 'afoco_locations_full',
+            source: 'projects',
+            id: hoveredStateIdProjectsFill,
+          },
+          { hover: false }
+        );
+        hoveredStateIdProjectsFill = null;
+      }
     },
-    [setCursor, map, hoveredStateIdProjectsCircle]
+    [setCursor, map, hoveredStateIdProjectsCircle, hoveredStateIdProjectsFill]
   );
 
   return (

--- a/client/src/containers/map/index.tsx
+++ b/client/src/containers/map/index.tsx
@@ -10,7 +10,7 @@ import { useParams, useRouter } from 'next/navigation';
 import bbox from '@turf/bbox';
 import { useAtomValue, useSetAtom, useAtom } from 'jotai';
 
-import { bboxAtom, hoveredProjectAtom, layersInteractiveIdsAtom, tmpBboxAtom } from '@/store';
+import { bboxAtom, hoveredProjectMapAtom, layersInteractiveIdsAtom, tmpBboxAtom } from '@/store';
 
 import { Bbox } from '@/types/map';
 
@@ -55,7 +55,7 @@ export default function MapContainer() {
   const params = useParams<{ id: string }>();
 
   const layersInteractiveIds = useAtomValue(layersInteractiveIdsAtom);
-  const setHoveredProject = useSetAtom(hoveredProjectAtom);
+  const setHoveredProjectMap = useSetAtom(hoveredProjectMapAtom);
   const [cursor, setCursor] = useState<'grab' | 'pointer'>('grab');
 
   const [bboxA, setBbox] = useAtom(bboxAtom);
@@ -125,12 +125,12 @@ export default function MapContainer() {
       // *ON MOUSE ENTER
       if (e.features && map && ProjectsLayer) {
         setCursor('pointer');
-        setHoveredProject(ProjectsLayer.properties?.project_code);
+        setHoveredProjectMap(ProjectsLayer.properties?.project_code);
       }
 
       if (e.features && map && ProjectsFillLayer) {
         setCursor('pointer');
-        setHoveredProject(ProjectsFillLayer.properties?.project_code);
+        setHoveredProjectMap(ProjectsFillLayer.properties?.project_code);
       }
 
       if (ProjectsLayer && map) {
@@ -185,7 +185,7 @@ export default function MapContainer() {
       }
 
       if (!ProjectsLayer && map && hoveredStateIdProjectsCircle) {
-        setHoveredProject(null);
+        setHoveredProjectMap(null);
 
         map?.setFeatureState(
           {
@@ -198,7 +198,7 @@ export default function MapContainer() {
         hoveredStateIdProjectsCircle = null;
       }
       if (!ProjectsFillLayer && map && hoveredStateIdProjectsFill) {
-        setHoveredProject(null);
+        setHoveredProjectMap(null);
 
         map?.setFeatureState(
           {

--- a/client/src/containers/map/layer-manager/index.tsx
+++ b/client/src/containers/map/layer-manager/index.tsx
@@ -6,8 +6,6 @@ import { useSetAtom } from 'jotai';
 
 import { layersInteractiveIdsAtom } from '@/store';
 
-import type { LayerProps } from '@/types/layers';
-
 import { useSyncLayers } from '@/hooks/datasets/sync-query';
 
 import { LAYERS } from '@/containers/datasets/layers';
@@ -20,14 +18,14 @@ const LayerManager = () => {
   const setInteractiveLayerIds = useSetAtom(layersInteractiveIdsAtom);
 
   const handleAdd = useCallback(
-    (styleIds: LayerProps['id'][]) => {
+    (styleIds: string[]) => {
       setInteractiveLayerIds((prevInteractiveIds) => [...prevInteractiveIds, ...styleIds]);
     },
     [setInteractiveLayerIds]
   );
 
   const handleRemove = useCallback(
-    (styleIds: LayerProps['id'][]) => {
+    (styleIds: string[]) => {
       setInteractiveLayerIds((prevInteractiveIds) => [
         ...prevInteractiveIds.filter((id) => !styleIds.includes(id)),
       ]);

--- a/client/src/containers/map/layer-manager/index.tsx
+++ b/client/src/containers/map/layer-manager/index.tsx
@@ -1,4 +1,12 @@
+import { useCallback } from 'react';
+
 import { Layer } from 'react-map-gl';
+
+import { useSetAtom } from 'jotai';
+
+import { layersInteractiveIdsAtom } from '@/store';
+
+import type { LayerProps } from '@/types/layers';
 
 import { useSyncLayers } from '@/hooks/datasets/sync-query';
 
@@ -9,6 +17,23 @@ import { DeckMapboxOverlayProvider } from '@/components/map/provider';
 const LayerManager = () => {
   const [layers] = useSyncLayers();
   const layersIds = layers.map((l) => l.id);
+  const setInteractiveLayerIds = useSetAtom(layersInteractiveIdsAtom);
+
+  const handleAdd = useCallback(
+    (styleIds: LayerProps['id'][]) => {
+      setInteractiveLayerIds((prevInteractiveIds) => [...prevInteractiveIds, ...styleIds]);
+    },
+    [setInteractiveLayerIds]
+  );
+
+  const handleRemove = useCallback(
+    (styleIds: LayerProps['id'][]) => {
+      setInteractiveLayerIds((prevInteractiveIds) => [
+        ...prevInteractiveIds.filter((id) => !styleIds.includes(id)),
+      ]);
+    },
+    [setInteractiveLayerIds]
+  );
 
   return (
     <DeckMapboxOverlayProvider>
@@ -40,7 +65,15 @@ const LayerManager = () => {
           const LayerComponent = LAYERS[l];
           const beforeId = i === 0 ? 'custom-layers' : `${layersIds[i - 1]}-layer`;
 
-          return <LayerComponent id={l} key={l} beforeId={beforeId} />;
+          return (
+            <LayerComponent
+              id={l}
+              key={l}
+              beforeId={beforeId}
+              onAdd={handleAdd}
+              onRemove={handleRemove}
+            />
+          );
         })}
       </>
     </DeckMapboxOverlayProvider>

--- a/client/src/containers/panel/index.tsx
+++ b/client/src/containers/panel/index.tsx
@@ -7,23 +7,23 @@ import { ChevronLeft } from 'lucide-react';
 
 import { cn } from '@/lib/classnames';
 
-import { dashboardAtom, hoveredProjectAtom } from '@/store';
+import { dashboardAtom, hoveredProjectMapAtom } from '@/store';
 import { openAtom } from '@/store';
 
 import { Button } from '@/components/ui/button';
 
 export default function Panel({ children }: { children: React.ReactNode }) {
   const dashboard = useAtomValue(dashboardAtom);
-  const hoveredProject = useAtomValue(hoveredProjectAtom);
+  const hoveredProjectMap = useAtomValue(hoveredProjectMapAtom);
   const [open, setOpen] = useAtom(openAtom);
 
   const scrollRef = useRef(null);
 
   useEffect(() => {
-    if (!hoveredProject) return;
-    const element = document.getElementById(hoveredProject);
+    if (!hoveredProjectMap) return;
+    const element = document.getElementById(hoveredProjectMap);
     element?.scrollIntoView({ behavior: 'smooth' });
-  }, [hoveredProject]);
+  }, [hoveredProjectMap]);
 
   return (
     <div

--- a/client/src/containers/projects/item.tsx
+++ b/client/src/containers/projects/item.tsx
@@ -36,8 +36,11 @@ export default function ProjectItem({ data }: { data: ProjectListResponseDataIte
           height={300}
           className="w-1/3"
         />
-        <div className="flex w-2/3 flex-col space-y-2">
-          <h3 className="line-clamp-4 text-sm font-bold text-yellow-900" id="project-detail-title">
+        <div className="flex w-2/3 flex-col justify-between">
+          <h3
+            className="line-clamp-4 text-left text-sm font-bold text-yellow-900"
+            id="project-detail-title"
+          >
             {data?.attributes?.name}
           </h3>
           <div className="text-2xs flex space-x-6 pb-2.5 text-gray-500">

--- a/client/src/containers/projects/item.tsx
+++ b/client/src/containers/projects/item.tsx
@@ -7,14 +7,14 @@ import { useAtomValue } from 'jotai';
 
 import { cn } from '@/lib/classnames';
 
-import { hoveredProjectAtom } from '@/store';
+import { hoveredProjectMapAtom } from '@/store';
 
 import { ProjectListResponseDataItem } from '@/types/generated/strapi.schemas';
 
 import { useSyncQueryParams } from '@/hooks/datasets';
 
 export default function ProjectItem({ data }: { data: ProjectListResponseDataItem }) {
-  const hoveredProject = useAtomValue(hoveredProjectAtom);
+  const hoveredProjectMap = useAtomValue(hoveredProjectMapAtom);
   const queryParams = useSyncQueryParams();
 
   return (
@@ -25,7 +25,7 @@ export default function ProjectItem({ data }: { data: ProjectListResponseDataIte
         className={cn({
           'flex space-x-4 rounded-lg border border-gray-100 bg-white py-2 pl-2 pr-4 shadow-sm transition-all duration-300 hover:border-yellow-500':
             true,
-          'border-yellow-500': hoveredProject === data?.attributes?.project_code,
+          'border-yellow-500': hoveredProjectMap === data?.attributes?.project_code,
         })}
         id={data?.attributes?.project_code}
       >

--- a/client/src/containers/projects/item.tsx
+++ b/client/src/containers/projects/item.tsx
@@ -25,9 +25,9 @@ export default function ProjectItem({ data }: { data: ProjectListResponseDataIte
         className={cn({
           'flex space-x-4 rounded-lg border border-gray-100 bg-white py-2 pl-2 pr-4 shadow-sm transition-all duration-300 hover:border-yellow-500':
             true,
-          'border-yellow-500': hoveredProject === data?.id?.toString(),
+          'border-yellow-500': hoveredProject === data?.attributes?.project_code,
         })}
-        id={data?.id?.toString()}
+        id={data?.attributes?.project_code}
       >
         <Image
           src="/images/projects/placeholder.png"

--- a/client/src/containers/projects/list.tsx
+++ b/client/src/containers/projects/list.tsx
@@ -1,7 +1,11 @@
 'use client';
-import { useState } from 'react';
 
+import { useCallback, useState, MouseEvent } from 'react';
+
+import { useSetAtom } from 'jotai';
 import { Search, X } from 'lucide-react';
+
+import { hoveredProjectListAtom } from '@/store';
 
 import { useGetProjects } from '@/types/generated/project';
 
@@ -18,6 +22,7 @@ import FiltersSelected from '../filters/selected';
 export default function ProjectsList() {
   const [searchValue, setSearchValue] = useState<string | null>(null);
   const [filtersSettings] = useSyncFilters();
+  const setHoveredProjectList = useSetAtom(hoveredProjectListAtom);
 
   const { data, isFetching, isFetched, isError } = useGetProjects(
     {
@@ -124,6 +129,14 @@ export default function ProjectsList() {
     }
   );
 
+  const handleHover = useCallback(
+    (e: MouseEvent<HTMLElement>) => {
+      const currentValue = e.currentTarget.getAttribute('data-value');
+      setHoveredProjectList(currentValue);
+    },
+    [setHoveredProjectList]
+  );
+
   return (
     <ContentLoader
       data={data}
@@ -158,7 +171,18 @@ export default function ProjectsList() {
           <Filters nrResults={data?.length as number} />
         </div>
         <FiltersSelected />
-        {data && data.map((project) => <ProjectItem key={project?.id} data={project} />)}
+        {data &&
+          data.map((project) => (
+            <button
+              type="button"
+              key={project?.id}
+              data-value={project?.attributes?.project_code}
+              onMouseEnter={handleHover}
+              onMouseLeave={() => setHoveredProjectList(null)}
+            >
+              <ProjectItem data={project} />
+            </button>
+          ))}
       </div>
     </ContentLoader>
   );

--- a/client/src/hooks/datasets/query-parsers.ts
+++ b/client/src/hooks/datasets/query-parsers.ts
@@ -7,7 +7,9 @@ import type { FilterSettings } from '@/containers/filters/types';
 
 export const filtersParser = parseAsJson<FilterSettings>().withDefault({});
 
-export const layersParser = parseAsJson<LayerSettings[]>().withDefault([]);
+export const layersParser = parseAsJson<LayerSettings[]>().withDefault([
+  { id: 5, visibility: 'visible', opacity: 1 },
+]);
 
 export const basemapSettingsParser = parseAsJson<MapSettings>().withDefault({
   basemap: 'basemap-light',

--- a/client/src/store/index.ts
+++ b/client/src/store/index.ts
@@ -15,7 +15,7 @@ export const tmpBboxAtom = atom<readonly [number, number, number, number] | null
 
 // Map layers
 
-export const layersInteractiveIdsAtom = atom<number[]>([]);
+export const layersInteractiveIdsAtom = atom<string[]>([]);
 
 export const popupAtom = atom<MapLayerMouseEvent | null>(null);
 
@@ -26,7 +26,11 @@ export const mapSettingsAtom = atom<MapSettings>({
   roads: false,
 });
 
-export const hoveredProjectAtom = atom<string | null>(null);
+// set project code when hovering a project in the map
+export const hoveredProjectMapAtom = atom<string | null>(null);
+
+// set project code when hovering a project from projects list in sidebar
+export const hoveredProjectListAtom = atom<string | null>(null);
 
 export const DEFAULT_SETTINGS = {
   expand: true,

--- a/client/src/store/index.ts
+++ b/client/src/store/index.ts
@@ -15,9 +15,7 @@ export const tmpBboxAtom = atom<readonly [number, number, number, number] | null
 
 // Map layers
 
-export const layersInteractiveAtom = atom<string[]>([]);
-
-export const layersInteractiveIdsAtom = atom<string[]>(['projects']);
+export const layersInteractiveIdsAtom = atom<string[]>(['projects', 'projects_fill']);
 
 export const popupAtom = atom<MapLayerMouseEvent | null>(null);
 

--- a/client/src/store/index.ts
+++ b/client/src/store/index.ts
@@ -15,7 +15,7 @@ export const tmpBboxAtom = atom<readonly [number, number, number, number] | null
 
 // Map layers
 
-export const layersInteractiveIdsAtom = atom<string[]>(['projects', 'projects_fill']);
+export const layersInteractiveIdsAtom = atom<number[]>([]);
 
 export const popupAtom = atom<MapLayerMouseEvent | null>(null);
 

--- a/client/src/types/layers.ts
+++ b/client/src/types/layers.ts
@@ -1,5 +1,3 @@
-import type { LayerProps as RMGLLayerProps } from 'react-map-gl';
-
 import type { Layer as DeckLayer } from '@deck.gl/core/typed';
 import type { AnyLayer, AnySourceData } from 'mapbox-gl';
 
@@ -53,8 +51,8 @@ export type InteractionConfig = {
 export type LayerProps = {
   id: number;
   zIndex?: number;
-  onAdd?: (ids: RMGLLayerProps['id'][]) => void;
-  onRemove?: (ids: RMGLLayerProps['id'][]) => void;
+  onAdd?: (ids: (string | undefined)[]) => void;
+  onRemove?: (ids: (string | undefined)[]) => void;
   beforeId: string;
   settings?: { opacity: LayerSettings['opacity']; visibility: LayerSettings['visibility'] };
 };

--- a/client/src/types/layers.ts
+++ b/client/src/types/layers.ts
@@ -1,4 +1,6 @@
-import { Layer as DeckLayer } from '@deck.gl/core/typed';
+import type { LayerProps as RMGLLayerProps } from 'react-map-gl';
+
+import type { Layer as DeckLayer } from '@deck.gl/core/typed';
 import type { AnyLayer, AnySourceData } from 'mapbox-gl';
 
 export type Config = {
@@ -51,8 +53,8 @@ export type InteractionConfig = {
 export type LayerProps = {
   id: number;
   zIndex?: number;
-  onAdd?: () => void;
-  onRemove?: (ids: string[]) => void;
+  onAdd?: (ids: RMGLLayerProps['id'][]) => void;
+  onRemove?: (ids: RMGLLayerProps['id'][]) => void;
   beforeId: string;
   settings?: { opacity: LayerSettings['opacity']; visibility: LayerSettings['visibility'] };
 };


### PR DESCRIPTION
## Projects layer

### Overview

- Fix scroll changing id for project_code
- Adds hovering effect for geometries in project's layer
- Add/remove interactivity in layer instead of hardcoding (before we were adding interactivity even if the layer was not present)
- Filters projects layer by centroid
- Set projects layer active by default
- Filters and highlight projects on the map based on hovering on a specific project on the sidebar

Note: There is a weird behavior not related to this PR. when the map on Worldwide view just some projects appear and when you zoom in you get more. That is how the layer behaves in [mapbox](https://studio.mapbox.com/tilesets/afoco.1xqij8g6/#7.21/11.758/103.866). It's a bug registered [here](https://vizzuality.atlassian.net/browse/AF-117?atlOrigin=eyJpIjoiOTdlN2IxNmJlM2VmNGY1ODliMGFkOWYyMTliMjAxMTAiLCJwIjoiaiJ9)

### Testing instructions

_Go to projects list and interact with projects and layer_

### Feature relevant tickets

_[AF-63](https://vizzuality.atlassian.net/jira/software/c/projects/AF/boards/96?search=a&selectedIssue=AF-63)_
_[AF-110](https://vizzuality.atlassian.net/jira/software/c/projects/AF/boards/96?search=a&selectedIssue=AF-110)_

---

## Checklist before submitting

- [ ] Meaningful commits and code rebased on `develop`.
- [ ] Update CHANGELOG
- [ ] If this PR adds feature that should be tested for regressions when
      deploying to staging/production, please add brief testing instructions
      to the deploy checklist 


[AF-63]: https://vizzuality.atlassian.net/browse/AF-63?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AF-110]: https://vizzuality.atlassian.net/browse/AF-110?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ